### PR TITLE
MAVEN-9 : -Dmaven.test.failure.ignore=true has no effect on test failures

### DIFF
--- a/src/main/java/org/grails/maven/plugin/MvnFunctionalTestMojo.java
+++ b/src/main/java/org/grails/maven/plugin/MvnFunctionalTestMojo.java
@@ -50,6 +50,14 @@ public class MvnFunctionalTestMojo extends AbstractGrailsMojo {
      */
     private Boolean mavenSkip;
 
+    /**
+ 	* Set this to "true" to ignore a failure during testing. Its use is NOT RECOMMENDED, but quite convenient on
+ 	* occasion.
+ 	*
+ 	* @parameter default-value="false" expression="${maven.test.failure.ignore}"
+ 	*/
+ 	private boolean testFailureIgnore;
+
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skip) {
             return;
@@ -59,6 +67,12 @@ public class MvnFunctionalTestMojo extends AbstractGrailsMojo {
             return;
         }
 
-        runGrails("TestApp", "--functional", true);
+        try {
+            runGrails("TestApp", "--functional", true);
+        } catch (MojoExecutionException me) {
+            if (!testFailureIgnore) {
+                throw me;
+            }
+        }
     }
 }

--- a/src/main/java/org/grails/maven/plugin/MvnTestMojo.java
+++ b/src/main/java/org/grails/maven/plugin/MvnTestMojo.java
@@ -50,6 +50,14 @@ public class MvnTestMojo extends AbstractGrailsMojo {
      */
     private Boolean mavenSkip;
 
+    /**
+ 	* Set this to "true" to ignore a failure during testing. Its use is NOT RECOMMENDED, but quite convenient on
+ 	* occasion.
+ 	*
+ 	* @parameter default-value="false" expression="${maven.test.failure.ignore}"
+ 	*/
+ 	private boolean testFailureIgnore;
+
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skip) {
             return;
@@ -73,6 +81,12 @@ public class MvnTestMojo extends AbstractGrailsMojo {
             }
         }
 
-        runGrails("TestApp", "--unit --integration", true);
+        try {
+            runGrails("TestApp", "--unit --integration", true);
+        } catch (MojoExecutionException me) {
+            if (!testFailureIgnore) {
+                throw me;
+            }
+        }
     }
 }


### PR DESCRIPTION
This request adds parameter maven.test.failure.ignore to the grails-maven-plugin.
