### PR TITLE
Added Configuration Option to Enable --stacktrace

### DIFF
--- a/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
+++ b/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
@@ -114,13 +114,6 @@ public abstract class AbstractGrailsMojo extends AbstractMojo {
 	protected boolean showStacktrace;
 
     /**
-     * Turns on/off stacktraces in the console output for Grails commands.
-     *
-     * @parameter expression="${showStacktrace}" default-value="false"
-     */
-    protected boolean showStacktrace;
-
-    /**
      * Whether the JVM is forked for executing Grails commands
      *
      * @parameter expression="${fork}" default-value="false"


### PR DESCRIPTION
Added a configuration option to the AbstractGrailsMojo that when set to true enables the addition of the --stacktrace option to the argument list passed to the executed Grails command(s).
