### PR TITLE
Move target java version support to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,8 +327,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
pumped the maven compiler's target java support to 1.6 per #MAVEN-37 jira
