### PR TITLE
Code changes for Agent Reloading and Forked VM Parameters

### DIFF
--- a/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
+++ b/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
@@ -122,12 +122,18 @@ public abstract class AbstractGrailsMojo extends AbstractMojo {
     protected boolean fork = false;
 
     /**
+     * List of arguments passed to the forked VM
+     *
+     * @parameter
+     */
+    protected List forkedVmArgs;
+
+    /**
      * Whether the JVM is forked for executing Grails commands
      *
      * @parameter expression="${forkDebug}" default-value="false"
      */
     protected boolean forkDebug = false;
-
 
     /**
      * Whether the JVM is forked for executing Grails commands
@@ -298,7 +304,7 @@ public abstract class AbstractGrailsMojo extends AbstractMojo {
             ec.setTestClassesDir(new File(targetDir, "test-classes"));
             ec.setResourcesDir(new File(targetDir, "resources"));
             ec.setProjectPluginsDir(this.pluginsDir);
-
+            ec.setForkedVmArgs(this.forkedVmArgs);
 
             // If the command is running in non-interactive mode, we
             // need to pass on the relevant argument.

--- a/src/main/java/org/grails/maven/plugin/tools/ForkedGrailsRuntime.java
+++ b/src/main/java/org/grails/maven/plugin/tools/ForkedGrailsRuntime.java
@@ -75,6 +75,11 @@ public class ForkedGrailsRuntime {
             if(reloadingAgent != null) {
                 cmd.addAll(Arrays.asList("-javaagent:" + reloadingAgent.getCanonicalPath(), "-noverify", "-Dspringloaded=profile=grails"));
             }
+            if(null != executionContext.getForkedVmArgs()
+            && executionContext.getForkedVmArgs().size() > 0) {
+                cmd.addAll(executionContext.getForkedVmArgs());
+            }
+
             cmd.add(getClass().getName());
             processBuilder
                     .directory(executionContext.baseDir)
@@ -245,6 +250,7 @@ public class ForkedGrailsRuntime {
         private List<File> buildDependencies;
         private List<File> providedDependencies;
         private List<File> testDependencies;
+        private List forkedVmArgs;
         
         private File grailsWorkDir;
         private File projectWorkDir;
@@ -257,6 +263,7 @@ public class ForkedGrailsRuntime {
         private String scriptName;
         private String env;
         private String args;
+
 
         public String getScriptName() {
             return scriptName;
@@ -280,6 +287,14 @@ public class ForkedGrailsRuntime {
 
         public void setArgs(String args) {
             this.args = args;
+        }
+
+        public List<String> getForkedVmArgs() {
+            return forkedVmArgs;
+        }
+
+        public void setForkedVmArgs(List<String> forkedVmArgs) {
+            this.forkedVmArgs = forkedVmArgs;
         }
 
         public File getBaseDir() {


### PR DESCRIPTION
MAVEN-178 - There is no way to toggle reloading agent due to missing annotation in AbstractGrailsMojo
MAVEN-177 - Command line parameters not passed to forked JVM
