### PR TITLE
MAVEN-191 - grails-maven-plugin fails with JDK7 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -638,6 +638,7 @@
             <activation>
                 <os>
                     <family>unix</family>
+		    <name>!mac os x</name> <!-- needed due to MNG-4983 -->
                 </os>
             </activation>
             <dependencies>
@@ -647,23 +648,6 @@
                     <version>1.6</version>
                     <scope>system</scope>
                     <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>jdk_mac</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools</artifactId>
-                    <version>1.6</version>
-                    <scope>system</scope>
-                    <systemPath>${java.home}/bundle/Classes/classes.jar</systemPath>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
Fixes the same bug as http://jira.grails.org/browse/MAVEN-186 . For some reason, it wasn't merged here: https://github.com/grails/grails-maven/commit/c29e9191c16ad5447c9a9deae3c5d21f732820ed
