### PR TITLE
Fix dependency resolution for exec mojo

### DIFF
--- a/src/main/java/org/grails/maven/plugin/GrailsExecMojo.java
+++ b/src/main/java/org/grails/maven/plugin/GrailsExecMojo.java
@@ -27,7 +27,7 @@ import grails.util.GrailsNameUtils;
  * @description Executes an arbitrary Grails command.
  * @goal exec
  * @requiresProject false
- * @requiresDependencyResolution runtime
+ * @requiresDependencyResolution test
  * @since 0.4
  */
 public class GrailsExecMojo extends AbstractGrailsMojo {


### PR DESCRIPTION
The exec mojo needs to resolve all test artifacts as a requirements
since there is no way to guess which scope we need for the executing
script.

Otherwise, when calling mavenProject.getTestClasspathElements(), not all dependencies will be resolved correctly, and the projects own test resources will be missing
