### PR TITLE
Property to skip functional test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.grails</groupId>
     <artifactId>grails-maven-plugin</artifactId>
-    <version>2.2.4</version>
+    <version>2.2.4-BQ.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>Maven plugin for GRAILS applications</name>
@@ -314,7 +314,8 @@
 
     <build>
         <plugins>
-            <plugin>
+            <!--
+	    <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-gpg-plugin</artifactId>
               <executions>
@@ -326,7 +327,7 @@
                   </goals>
                 </execution>
               </executions>
-            </plugin>
+            </plugin> -->
                         
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/grails/maven/plugin/MvnFunctionalTestMojo.java
+++ b/src/main/java/org/grails/maven/plugin/MvnFunctionalTestMojo.java
@@ -20,7 +20,7 @@ import org.apache.maven.plugin.MojoFailureException;
 
 /**
  * Runs a Grails application's functional tests.
- *
+ * 
  * @author <a href="mailto:aheritier@gmail.com">Arnaud HERITIER</a>
  * @version $Id$
  * @description Runs a Grails application's functional tests.
@@ -32,56 +32,65 @@ import org.apache.maven.plugin.MojoFailureException;
  */
 public class MvnFunctionalTestMojo extends AbstractGrailsMojo {
 
-    /**
-     * Set this to 'true' to bypass functional tests entirely. Its use is
-     * NOT RECOMMENDED, but quite convenient on occasion.
-      * @parameter default-value="false" expression="${skipTests}"
-      * @since 0.4
-      */
-     private boolean skipTests;
+	/**
+	 * Set this to 'true' to bypass functional tests entirely. Its use is NOT RECOMMENDED, but quite convenient on
+	 * occasion.
+	 * 
+	 * @parameter default-value="false" expression="${skipTests}"
+	 * @since 0.4
+	 */
+	private boolean skipTests;
 
-     /**
-      * Set this to 'true' to bypass functional tests entirely. Its use is
-      * NOT RECOMMENDED, but quite convenient on occasion.
-      *
-     * @parameter expression="${grails.test.skip}"
-     * @since 0.3
-     */
-    private boolean skip;
+	/**
+	 * Set this to 'true' to bypass functional tests entirely. Its use is NOT RECOMMENDED, but quite convenient on
+	 * occasion.
+	 * 
+	 * @parameter expression="${grails.test.skip}"
+	 * @since 0.3
+	 */
+	private boolean skip;
 
-    /**
-     * Set this to 'true' to bypass functional tests entirely. Its use is
-     * NOT RECOMMENDED, but quite convenient on occasion.
-     *
-     * @parameter expression="${maven.test.skip}"
-     * @since 0.3
-     */
-    private Boolean mavenSkip;
+	/**
+	 * Set this to 'true' to bypass functional tests entirely. Its use is NOT RECOMMENDED, but quite convenient on
+	 * occasion.
+	 * 
+	 * @parameter expression="${grails.functionalTest.skip}"
+	 */
+	private boolean skipFunction;
 
-    /**
-     * Set this to "true" to ignore a failure during testing. Its use is NOT RECOMMENDED, but quite convenient on
-     * occasion.
-     *
-     * @parameter default-value="false" expression="${maven.test.failure.ignore}"
-     */
-    private boolean testFailureIgnore;
+	/**
+	 * Set this to 'true' to bypass functional tests entirely. Its use is NOT RECOMMENDED, but quite convenient on
+	 * occasion.
+	 * 
+	 * @parameter expression="${maven.test.skip}"
+	 * @since 0.3
+	 */
+	private Boolean mavenSkip;
 
-    public void execute() throws MojoExecutionException, MojoFailureException {
-        if (skipTests || skip || (mavenSkip != null && mavenSkip.booleanValue())) {
-            getLog().info("Functional tests are skipped.");
-            return;
-        }
+	/**
+	 * Set this to "true" to ignore a failure during testing. Its use is NOT RECOMMENDED, but quite convenient on
+	 * occasion.
+	 * 
+	 * @parameter default-value="false" expression="${maven.test.failure.ignore}"
+	 */
+	private boolean testFailureIgnore;
 
-        try {
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (skipTests || skip || skipFunction || (mavenSkip != null && mavenSkip.booleanValue())) {
+			getLog().info("Functional tests are skipped.");
+			return;
+		}
 
-            if(getEnvironment() == null) {
-                env = "test";
-            }
-            runGrails("TestApp", "--unit --integration --functional");
-        } catch (MojoExecutionException me) {
-            if (!testFailureIgnore) {
-                throw me;
-            }
-        }
-    }
+		try {
+
+			if (getEnvironment() == null) {
+				env = "test";
+			}
+			runGrails("TestApp", "--unit --integration --functional");
+		} catch (MojoExecutionException me) {
+			if (!testFailureIgnore) {
+				throw me;
+			}
+		}
+	}
 }


### PR DESCRIPTION
There are cases when the application cannot be bootstrapped on the build server (CI) due to environmental dependencies. For these cases you may want to execute unit test on the build server but not functional test. I added a property that allows you to disable the functional test without disabling unit testing.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/grails/grails-maven/28)

<!-- Reviewable:end -->
