### PR TITLE
remove extra runGrails line (fix MAVEN-209)

### DIFF
--- a/src/main/java/org/grails/maven/plugin/GrailsTestAppMojo.java
+++ b/src/main/java/org/grails/maven/plugin/GrailsTestAppMojo.java
@@ -48,7 +48,6 @@ public class GrailsTestAppMojo extends AbstractGrailsMojo {
         if(getEnvironment() == null) {
             env = "test";
         }
-        runGrails("TestApp");
 
         String args = null;
 


### PR DESCRIPTION
There is an extra runGrails() that causes tests to be excuted twice - see: http://jira.grails.org/browse/MAVEN-209
