### PR TITLE
MAVEN-220: Update jline and groovy versions to match Grails 2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <maven.version>2.0.5</maven.version>
 
         <!-- Dependencies -->
-        <groovy.version>2.1.8</groovy.version>
+        <groovy.version>2.1.9</groovy.version>
         <grails.version>2.3.2</grails.version>
         <grails-bootstrap.version>${grails.version}</grails-bootstrap.version>
         <grails-core.version>${grails.version}</grails-core.version>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>jline</groupId>
             <artifactId>jline</artifactId>
-            <version>1.0</version>
+            <version>2.11</version>
         </dependency>
         
         <dependency>

--- a/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
+++ b/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
@@ -17,7 +17,7 @@
 package org.grails.maven.plugin;
 
 import grails.util.Metadata;
-import jline.Terminal;
+import jline.TerminalFactory;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.artifact.factory.ArtifactFactory;
@@ -567,7 +567,7 @@ public abstract class AbstractGrailsMojo extends AbstractMojo {
         } catch (final Exception ex) {
             throw new MojoExecutionException("Unable to start Grails", ex);
         } finally {
-            Terminal.resetTerminal();
+            TerminalFactory.reset();
             System.setIn(currentIn);
             System.setOut(currentOutput);
         }


### PR DESCRIPTION
Also accounted for jline2 interface change

For JIRA issue: http://jira.grails.org/browse/MAVEN-220
