### PR TITLE
Use grails-dependencies artifact's Maven groupId coordinate to ensure that the correct version is used

### DIFF
--- a/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
+++ b/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
@@ -630,7 +630,8 @@ public abstract class AbstractGrailsMojo extends AbstractMojo {
         Set dependencyArtifacts = project.getDependencyArtifacts();
         for (Object o : dependencyArtifacts) {
             Artifact artifact = (Artifact) o;
-            if (artifact.getArtifactId().equals("grails-dependencies")) {
+            if (artifact.getArtifactId().equals("grails-dependencies") &&
+                artifact.getGroupId().equals("org.grails")) {
                 return artifact;
             }
         }


### PR DESCRIPTION
The Grails version retrieval via the official Grails dependencies Maven artifact (org.grails:grails-dependencies) in the Maven project's dependency set should be more restrictive.  
I found that if I have another Maven artifact (internal artifact used for development purposes) with the artifactId of "grails-dependencies" in my Maven project then the version number from that artifact is used instead.  This change will ensure that the official Grails dependencies artifact's version will be used.
