### PR TITLE
Make "test-app" goal behave more like Grails "test-app" command

### DIFF
--- a/src/main/java/org/grails/maven/plugin/GrailsTestAppMojo.java
+++ b/src/main/java/org/grails/maven/plugin/GrailsTestAppMojo.java
@@ -31,34 +31,35 @@ import org.apache.maven.plugin.MojoFailureException;
  */
 public class GrailsTestAppMojo extends AbstractGrailsMojo {
 
-    /**
-     *  The space-separated list of test classes to run (e.g. *Controller)
-     *
-     * @parameter expression="${testPatterns}"
-     */
-    private String testPatterns;
-    /**
-     * The space-separated list of test types or phases (e.g unit: :spock)
-     *
-     * @parameter expression="${testTypesAndPhases}"
-     */
-    private String testTypesAndPhases;
+	/**
+	 *  The space-separated list of test classes to run (e.g. *Controller)
+	 *
+	 * @parameter expression="${testPatterns}"
+	 */
+	private String testPatterns;
+	/**
+	 * The space-separated list of test types or phases (e.g unit: :spock)
+	 *
+	 * @parameter expression="${testTypesAndPhases}"
+	 */
+	private String testTypesAndPhases;
 
-    public void execute() throws MojoExecutionException, MojoFailureException {
-        if(getEnvironment() == null) {
-            env = "test";
-        }
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if(getEnvironment() == null) {
+			env = "test";
+		}
 
-        String args = null;
+		String args = null;
 
-        if (testTypesAndPhases != null) {
-            args = testTypesAndPhases;
-        }
+		if (testTypesAndPhases != null) {
+			args = testTypesAndPhases;
+		}
 
-        if (testPatterns != null) {
-            args = (args != null) ? args + " " + testPatterns : testPatterns;
-        }
+		if (testPatterns != null) {
+			args = (args != null) ? args + " " + testPatterns : testPatterns;
+		}
 
-        runGrails("TestApp", args != null ? args : System.getProperty("grails.cli.args"));
-    }
+		runGrails("TestApp", args != null ? args : System.getProperty("grails.cli.args"));
+	}
 }


### PR DESCRIPTION
The Grails Maven plugin's TestApp Mojo currently does not behave the same as the Grails "test-app" command line, which can be confusing when projects are converted to use Maven.  Specifically, the mojo currently runs the unit and integration tests, then re-runs the tests using the `testPatterns` and `testTypesAndPhases` arguments.  This is different than the `test-app` command, which only runs tests once, using whatever arguments are provided and defaulting to unit and integration tests if no arguments are present.  The change in this PR makes the mojo behave exactly like the `test-app` command with regards to only executing the tests once based on the provided arguments.
