### PR TITLE
fix regression around how plugin names are identified

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <junit.version>4.11</junit.version>
         <maven-plugin-testing-harness.version>3.1.0</maven-plugin-testing-harness.version>
         <xmlunit.version>1.0</xmlunit.version>
+        <spock.version>0.7-groovy-2.0</spock.version>
     </properties>
 
     <prerequisites>
@@ -204,6 +205,27 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <version>${spock.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit-dep</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
 
 
     </dependencies>
@@ -226,12 +248,52 @@
                         
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
+                    <includes>
+                        <include>**/*Test.*</include>
+                        <include>**/*Spec.*</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                   <groupId>org.codehaus.mojo</groupId>
+                   <artifactId>build-helper-maven-plugin</artifactId>
+                   <version>1.7</version>
+                   <executions>
+                     <execution>
+                           <id>add-test-source</id>
+                           <phase>generate-test-sources</phase>
+                           <goals>
+                             <goal>add-test-source</goal>
+                           </goals>
+                           <configuration>
+                             <sources>
+                                   <source>src/test/groovy</source>
+                             </sources>
+                           </configuration>
+                     </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <compilerId>groovy-eclipse-compiler</compilerId>
+                     <sourceIncludes>
+                        <sourceInclude>**/*.groovy</sourceInclude>
+                      </sourceIncludes>
+                     <source>1.6</source>
                     <target>1.6</target>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-compiler</artifactId>
+                        <version>2.7.0-01</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>

--- a/src/main/java/org/grails/maven/plugin/tools/DefaultGrailsServices.java
+++ b/src/main/java/org/grails/maven/plugin/tools/DefaultGrailsServices.java
@@ -61,6 +61,22 @@ public class DefaultGrailsServices extends AbstractLogEnabled implements GrailsS
         }
         return buf.toString();
     }
+
+    /**
+   	 * The regular expression used to find camel case boundaries with a string.
+   	 */
+   	private static final String CAMEL_CASE_CONVERSION = "([a-z0-9])(?=[A-Z])";
+
+    /**
+     * Converts FooBar into foo-bar. Empty and null strings are returned as-is.
+     *
+     * @param name The lower case hyphen separated name
+     * @return The class name equivalent.
+     */
+    public static String getLowerCaseHyphenSeparatedName(String name) {
+        if (name == null || name.length() == 0) return name;
+        return name.replaceAll(CAMEL_CASE_CONVERSION, "$1-").toLowerCase();
+    }
 //    private List _dependencyPaths;
 
     private File getBasedir() {
@@ -138,7 +154,7 @@ public class DefaultGrailsServices extends AbstractLogEnabled implements GrailsS
         pluginProject.setFileName(descriptor);
 
         final String className = descriptor.getName().substring(0, descriptor.getName().length() - ".groovy".length());
-        final String pluginName = getClassNameForLowerCaseHyphenSeparatedName(getLogicalName(className, "GrailsPlugin"));
+        final String pluginName = getLowerCaseHyphenSeparatedName(getLogicalName(className, "GrailsPlugin"));
         pluginProject.setPluginName(pluginName);
 
         final GroovyClassLoader classLoader = new GroovyClassLoader();

--- a/src/test/groovy/org/grails/maven/plugin/tools/DefaultGrailsServicesSpec.groovy
+++ b/src/test/groovy/org/grails/maven/plugin/tools/DefaultGrailsServicesSpec.groovy
@@ -1,0 +1,26 @@
+package org.grails.maven.plugin.tools
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * @author Ryan Gardner
+ * @date 6/6/14
+ */
+class DefaultGrailsServicesSpec extends Specification {
+
+    @Unroll
+    def "the string {string} is converted to {expected} properly when calling the getLowerCaseHyphenSeparatedName method"() {
+        expect:
+            DefaultGrailsServices.getLowerCaseHyphenSeparatedName(string) == expected
+        where:
+            string      | expected
+            'FooBarBaz' | 'foo-bar-baz'
+            'Foo'       | 'foo'
+            ''          | ''
+            'fooNASA'   | 'foo-nasa'
+            null        | null
+
+    }
+
+}


### PR DESCRIPTION
This addresses the regression identified in https://github.com/grails/grails-maven/issues/43 

I added test dependencies on the spock framework to the pom to facilitate adding a simple unit test around the new method I was adding. 

This should also make it possible to add more unit tests to this plugin in the future. 
