### PR TITLE
Update maven plugin for Grails 2.3.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.grails</groupId>
     <artifactId>grails-maven-plugin</artifactId>
-    <version>2.3.9-SNAPSHOT</version>
+    <version>2.3.11</version>
     <packaging>maven-plugin</packaging>
 
     <name>Maven plugin for GRAILS applications</name>
@@ -49,7 +49,7 @@
 
         <!-- Dependencies -->
         <groovy.version>2.1.9</groovy.version>
-        <grails.version>2.3.9.BUILD-SNAPSHOT</grails.version>
+        <grails.version>2.3.11</grails.version>
         <grails-bootstrap.version>${grails.version}</grails-bootstrap.version>
         <grails-core.version>${grails.version}</grails-core.version>
         <grails-scripts.version>${grails.version}</grails-scripts.version>
@@ -62,11 +62,11 @@
         <maven-archiver.version>2.2</maven-archiver.version>
         <plexus-utils.version>1.4.5</plexus-utils.version>
         <junit.version>4.11</junit.version>
-        <spring.version>3.2.5.RELEASE</spring.version>
+        <spring.version>3.2.9.RELEASE</spring.version>
         <maven-plugin-testing-harness.version>1.1</maven-plugin-testing-harness.version>
         <xmlunit.version>1.0</xmlunit.version>
-        <aspectjweaver.version>1.7.2</aspectjweaver.version>
-        <aspectjrt.version>1.7.2</aspectjrt.version>
+        <aspectjweaver.version>1.7.4</aspectjweaver.version>
+        <aspectjrt.version>1.7.4</aspectjrt.version>
 
         <!-- Reporting plugins -->
         <maven-project-info-reports-plugin.version>2.0.1</maven-project-info-reports-plugin.version>


### PR DESCRIPTION
When using a pom build, need the grails-maven-plugin version to match up with the grails version. 
