### PR TITLE
Fix grails version. should be 2.4.3. When 2.4.2 release, version was not...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.grails</groupId>
     <artifactId>grails-maven-plugin</artifactId>
-    <version>2.4.2</version>
+    <version>2.4.3</version>
     <packaging>maven-plugin</packaging>
 
     <name>Maven plugin for GRAILS applications</name>
@@ -49,7 +49,7 @@
 
         <!-- Dependencies -->
         <groovy.version>2.3.3</groovy.version>
-        <grails.version>2.4.1</grails.version>
+        <grails.version>2.4.3</grails.version>
         <grails-launcher.version>1.0.5</grails-launcher.version>
         <aether.version>1.0.0.v20140518</aether.version>
         <maven-model.version>${maven.version}</maven-model.version>


### PR DESCRIPTION
... bumped from 2.4.1 to 2.4.2. Then when

2.4.3 was released, version was just bumped by +1 from 2.4.1 to 2.4.2. Should be 2.4.3.

I guess the plugin should actually be 2.4.3.1 now? Not sure what you want to do.
