### PR TITLE
Added support for nonProxyHosts when using an active maven proxy

### DIFF
--- a/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
+++ b/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
@@ -752,11 +752,11 @@ public abstract class AbstractGrailsMojo extends AbstractMojo {
                 String noProxy = activeProxy.getNonProxyHosts();
                 String username = activeProxy.getUsername();
                 String password = activeProxy.getPassword();
-
                 System.setProperty("http.proxyHost", host);
                 System.setProperty("http.proxyPort", String.valueOf(port));
-                System.setProperty("http.nonProxyHosts", noProxy);
-
+                if (noProxy != null) {
+                    System.setProperty("http.nonProxyHosts", noProxy);
+                }
                 if (username != null) {
                     System.setProperty("http.proxyUser", username);
                 }

--- a/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
+++ b/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
@@ -749,11 +749,14 @@ public abstract class AbstractGrailsMojo extends AbstractMojo {
             if (activeProxy != null) {
                 String host = activeProxy.getHost();
                 int port = activeProxy.getPort();
+                String noProxy = activeProxy.getNonProxyHosts();
                 String username = activeProxy.getUsername();
                 String password = activeProxy.getPassword();
 
                 System.setProperty("http.proxyHost", host);
                 System.setProperty("http.proxyPort", String.valueOf(port));
+                System.setProperty("http.nonProxyHosts", noProxy);
+
                 if (username != null) {
                     System.setProperty("http.proxyUser", username);
                 }


### PR DESCRIPTION
I noticed strange behaviour when using this plugin with a proxy, I quickly realized nonProxyHosts is not evaluated at all by this plugin

Grails JIRA ticket: MAVEN-247