### PR TITLE
Fixed issue 63

### DIFF
--- a/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
+++ b/src/main/java/org/grails/maven/plugin/AbstractGrailsMojo.java
@@ -705,10 +705,10 @@ public abstract class AbstractGrailsMojo extends AbstractMojo {
         }
 
         Object appName = metadata.get(APP_NAME);
-        if (!project.getName().equals(appName)) {
+        if (!project.getArtifactId().equals(appName)) {
             metadata.put(APP_NAME, project.getName());
             result = true;
-        }
+        } 
 
         return result;
     }


### PR DESCRIPTION
Made it synchronize the app.name property with artifactId, not project.name since project.name is intended to be able to be a well-formatted, human-readable name.

All of the unit tests pass and it worked in our build.