### PR TITLE
Resolve the issues of groovy version mismatch for Grails 2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.grails</groupId>
     <artifactId>grails-maven-plugin</artifactId>
-    <version>2.4.3</version>
+    <version>2.4.5</version>
     <packaging>maven-plugin</packaging>
 
     <name>Maven plugin for GRAILS applications</name>
@@ -48,7 +48,7 @@
         <maven.version>3.1.0</maven.version>
 
         <!-- Dependencies -->
-        <groovy.version>2.3.3</groovy.version>
+        <groovy.version>2.4.3</groovy.version>
         <grails.version>2.4.3</grails.version>
         <grails-launcher.version>1.0.5</grails-launcher.version>
         <aether.version>1.0.0.v20140518</aether.version>


### PR DESCRIPTION
If the groovy version is mismatched then there is no way to use Grails 2.5.0 with Maven. This resolves the issue.